### PR TITLE
UI: Search suggestions improvement

### DIFF
--- a/components/blocks/tile.module.css
+++ b/components/blocks/tile.module.css
@@ -1,5 +1,5 @@
 .Container {
-  @apply rounded-md overflow-hidden flex justify-between flex-col cursor-pointer transform transition duration-100 ease-in-out;
+  @apply rounded-md overflow-hidden flex justify-between flex-col cursor-pointer transform transition duration-100 ease-in-out mt-4;
 }
 
 .Container:hover {

--- a/components/layouts/tileContainer.module.css
+++ b/components/layouts/tileContainer.module.css
@@ -1,3 +1,3 @@
 .Container {
-  @apply grid grid-cols-6 gap-4 my-6;
+  @apply grid grid-cols-6 gap-x-4 gap-y-1 my-4;
 }

--- a/components/navigation/navChild.js
+++ b/components/navigation/navChild.js
@@ -114,8 +114,10 @@ const NavChild = ({ slug, page, color, className }) => {
 
   return (
     <li className={`${classNames(styles.Container, className)} leading-none`}>
-      {link}
-      {subNav}
+      <a href={url}>
+        {link}
+        {subNav}
+      </a>
     </li>
   );
 };

--- a/components/utilities/floatingNav.module.css
+++ b/components/utilities/floatingNav.module.css
@@ -1,6 +1,7 @@
 .ListContainer {
-  @apply pt-4 pb-2 w-60 overflow-y-auto bg-white hidden lg:block;
+  @apply pt-4 pb-2 w-60 overflow-y-auto bg-white hidden lg:block fixed top-20 right-0;
   max-height: calc(100vh - 4.5rem);
+  overscroll-behavior-y: contain;
 }
 
 .List {

--- a/components/utilities/headerLink.js
+++ b/components/utilities/headerLink.js
@@ -35,9 +35,7 @@ const HeaderLink = ({ name, level, className, children }) => {
     <>
       <a name={hash} className={styles.HashLink} />
 
-      <Header
-        className={classNames(styles.HeaderContainer, "group", className)}
-      >
+      <Header className={classNames(styles.HeaderContainer, className)}>
         {children}
 
         {copied ? (

--- a/components/utilities/headerLink.module.css
+++ b/components/utilities/headerLink.module.css
@@ -5,6 +5,9 @@
 .HeaderContainer {
   @apply flex text-gray-90 items-center font-bold;
 }
+.HeaderContainer:hover .CopyLink {
+  @apply opacity-90;
+}
 .HeaderContainer li {
   @apply text-[#6B7280] !important;
 }
@@ -52,5 +55,5 @@ h1.HeaderContainer + a + h6 {
 }
 
 .CopyLink {
-  @apply cursor-pointer ml-4 pt-1 opacity-0 flex items-center hover:opacity-90 group-hover:opacity-90;
+  @apply cursor-pointer ml-4 pt-1 opacity-0 flex items-center;
 }

--- a/components/utilities/search.js
+++ b/components/utilities/search.js
@@ -141,7 +141,14 @@ const Search = () => {
   );
 
   function Hit(props) {
-    const id = props.hit.id ? props.hit.id : "text_snippet";
+    const category = props.hit.categories ? props.hit.categories[0] : "Page";
+    let snippet;
+    if (
+      props.hit._highlightResult &&
+      props.hit._highlightResult.content.matchLevel !== "none"
+    ) {
+      snippet = <Snippet attribute="content" hit={props.hit} />;
+    }
 
     return (
       <article
@@ -151,16 +158,15 @@ const Search = () => {
         )}
         tabIndex="-1"
       >
-        <>
-          {" "}
-          <section className={styles.TextContainer}>
-            <a href={props.hit.objectID}>
-              <h5 className={styles.HitTitle}>
-                <Highlight hit={props.hit} attribute="title"></Highlight>
-              </h5>
-            </a>
-          </section>
-        </>
+        <section className={styles.TextContainer}>
+          <a href={props.hit.objectID}>
+            <p className={styles.HitCategory}>{category}</p>
+            <h5 className={styles.HitTitle}>
+              <Highlight hit={props.hit} attribute="title"></Highlight>
+            </h5>
+          </a>
+          {snippet}
+        </section>
       </article>
     );
   }
@@ -250,6 +256,10 @@ const Search = () => {
                       searchClient={searchClient}
                     >
                       <div className="right-panel">
+                        <Configure
+                          attributesToSnippet={["content:20"]}
+                          snippetEllipsisText={"…"}
+                        />
                         <SearchBox id="search-box small" />
                         <Hits hitComponent={Hit} />
                       </div>

--- a/components/utilities/search.js
+++ b/components/utilities/search.js
@@ -257,7 +257,7 @@ const Search = () => {
                     >
                       <div className="right-panel">
                         <Configure
-                          attributesToSnippet={["content:20"]}
+                          attributesToSnippet={["content:15"]}
                           snippetEllipsisText={"…"}
                         />
                         <SearchBox id="search-box small" />

--- a/components/utilities/search.module.css
+++ b/components/utilities/search.module.css
@@ -66,7 +66,7 @@
 
 /* Hits */
 .HitContainer {
-  @apply m-0 p-4 flex cursor-pointer;
+  @apply m-0 px-4 py-3 flex cursor-pointer;
 }
 
 .ActiveHit {
@@ -103,7 +103,7 @@
 }
 
 .HitCategory {
-  @apply mb-0 text-xs tracking-tight leading-4 font-normal;
+  @apply my-0 text-xs tracking-tight leading-4 font-normal pb-1;
   @apply text-gray-70 !important;
 }
 


### PR DESCRIPTION
I worked on :

- Search results will now show snippets of the match for searched text

<img width="630" alt="Screenshot 2022-09-13 at 6 27 48 PM" src="https://user-images.githubusercontent.com/51777795/189907336-9fc58271-9bc8-48b1-a93c-402097c57a26.png">

- Minor styling fixes

Before :
<img width="882" alt="Screenshot 2022-09-13 at 6 30 19 PM" src="https://user-images.githubusercontent.com/51777795/189907745-2bb1f80a-5ab6-436c-8114-732d155117d8.png">

After :
<img width="865" alt="Screenshot 2022-09-13 at 6 30 25 PM" src="https://user-images.githubusercontent.com/51777795/189907750-6f6dce16-429c-4517-aebf-173cbcd30398.png">

