### PR TITLE
Changed navigation link of cloud icon to collate website

### DIFF
--- a/Constants/Common.constants.js
+++ b/Constants/Common.constants.js
@@ -1,0 +1,1 @@
+export const COLLATE_WEBSITE_LINK = "https://www.getcollate.io/";

--- a/components/navigation/header.js
+++ b/components/navigation/header.js
@@ -86,7 +86,7 @@ const Header = () => {
             </a>
             <a
               className="btn fw-500 btn-primary rounded-pill"
-              href="https://share.hsforms.com/1fstvMCeZRZKTYA4nG1VTPgcq0j9"
+              href="https://www.getcollate.io/"
               target="_blank"
             >
               <button className="bg-[#7147e8]  pl-[1.125] pr-[1.125] rounded-full w-[55.5px] h-[44px] justify-center">

--- a/components/navigation/header.js
+++ b/components/navigation/header.js
@@ -17,6 +17,7 @@ const ThemeToggle = dynamic(() => import("../utilities/themeToggle"), {
   ssr: false,
 });
 import Search from "../utilities/search";
+import { COLLATE_WEBSITE_LINK } from "../../Constants/Common.constants";
 
 const Header = () => {
   const [isSticky, setIsSticky] = useState(false);
@@ -86,7 +87,7 @@ const Header = () => {
             </a>
             <a
               className="btn fw-500 btn-primary rounded-pill"
-              href="https://www.getcollate.io/"
+              href={COLLATE_WEBSITE_LINK}
               target="_blank"
             >
               <button className="bg-[#7147e8]  pl-[1.125] pr-[1.125] rounded-full w-[55.5px] h-[44px] justify-center">

--- a/components/summaryTiles.js
+++ b/components/summaryTiles.js
@@ -5,6 +5,7 @@ import { ReactComponent as Knowledge } from "../images/icons/knowledge.svg";
 import { ReactComponent as Deployment } from "../images/icons/Deployment_tile.svg";
 import { ReactComponent as SaaS } from "../images/icons/saas.svg";
 import { ReactComponent as Connectors } from "../images/icons/connectors.svg";
+import { COLLATE_WEBSITE_LINK } from "../Constants/Common.constants";
 
 const SummaryTiles = () => {
   return (
@@ -24,7 +25,7 @@ const SummaryTiles = () => {
         text="Enjoy 100% of OpenMetadata with 0% of the hassle."
         background="purple-70"
         bordercolor="purple-70"
-        link="https://www.getcollate.io/"
+        link={COLLATE_WEBSITE_LINK}
         size="half"
       />
 

--- a/components/summaryTiles.js
+++ b/components/summaryTiles.js
@@ -24,7 +24,7 @@ const SummaryTiles = () => {
         text="Enjoy 100% of OpenMetadata with 0% of the hassle."
         background="purple-70"
         bordercolor="purple-70"
-        link="https://share.hsforms.com/1fstvMCeZRZKTYA4nG1VTPgcq0j9"
+        link="https://www.getcollate.io/"
         size="half"
       />
 


### PR DESCRIPTION
Changed redirection link for cloud icon in nav-bar to collate website


https://user-images.githubusercontent.com/51777795/205676204-7ab14002-ccab-4e78-bce6-7038c2bce320.mov





