### PR TITLE
Fix `helpful.js` memory leak

### DIFF
--- a/components/utilities/helpful.js
+++ b/components/utilities/helpful.js
@@ -83,9 +83,14 @@ const Helpful = ({ slug, sourcefile }) => {
     setIsHelpful(true);
   };
 
+  // Perform the route change cleanup function for the Helpful component inside a useEffect call,
+  // instead of using router.events.on("routeChangeComplete", handleRouteChange), because that
+  // adds new events progressively as you keep browsing the website, thus eventually leading to a memory leak.
   useEffect(() => {
-    router.events.on("routeChangeComplete", handleRouteChange);
-  });
+    return () => {
+      handleRouteChange();
+    };
+  }, [sourcefile]);
 
   let joinedSlug = "/";
   if (slug) {


### PR DESCRIPTION
Browsing many (15-30+) pages in succession on the same browser tab causes the tab to slow down and eventually crash due to a memory leak in the `helpful.js` component.  

![Screenshot 2023-02-06 at 16 35 42](https://user-images.githubusercontent.com/20672874/216962197-acf2f7be-99da-4d94-8e63-1a9c36f594b7.png)

That component is called every time one changes the page.  Over time, it stacks so many function calls that it breaks the site. The solution is to perform the route change cleanup function for the Helpful component inside a `useEffect` call instead of using `router.events.on("routeChangeComplete", handleRouteChange)`.