### PR TITLE
Make suggest edits button work

### DIFF
--- a/components/utilities/suggestEdits.js
+++ b/components/utilities/suggestEdits.js
@@ -7,7 +7,7 @@ const SuggestEdits = ({ sourcefile }) => {
         <i className={styles.Icon}>edit</i>
         <a
           className={styles.Link}
-          href="https://github.com/open-metadata/OpenMetadata/issues/new?assignees=&labels=documentation&template=doc_update.md&title="
+          href={sourcefile}
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -71,7 +71,7 @@ export default function Article({
 
   suggestEditURL = sourceFile
     ? sourceFile
-    : "https://github.com/open-metadata/docs/tree/publish" +
+    : "https://github.com/open-metadata/OpenMetadata/tree/main/openmetadata-docs" +
     filename.substring(filename.indexOf("/content/"));
 
   const components = {

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -69,7 +69,10 @@ export default function Article({
   let suggestEditURL;
   const { sourceFile } = useAppContext();
 
-  suggestEditURL = "https://github.com/open-metadata/docs/issues";
+  suggestEditURL = sourceFile
+    ? sourceFile
+    : "https://github.com/open-metadata/docs/tree/publish" +
+    filename.substring(filename.indexOf("/content/"));
 
   const components = {
     Note,
@@ -206,11 +209,10 @@ export default function Article({
             >
               <div className={classNames("content", styles.ContentContainer)}>
                 <MDXRemote {...source} components={components} />
-                {/* <Helpful slug={slug} sourcefile={suggestEditURL} /> */}
+                <Helpful slug={slug} sourcefile={suggestEditURL} />
               </div>
             </article>
             <Psa />
-            <Helpful />
             <div className={styles.Buttons}>{arrowContainer}</div>
           </section>
           <FloatingNav slug={slug} menu={menu} className="floatingNav" />
@@ -263,10 +265,10 @@ export async function getStaticProps(context) {
     props["source"] = source;
     props["currMenuItem"] = current
       ? {
-          name: current.name,
-          url: current.url,
-          isVersioned: !!current.isVersioned,
-        }
+        name: current.name,
+        url: current.url,
+        isVersioned: !!current.isVersioned,
+      }
       : null;
     props["nextMenuItem"] = next ? { name: next.name, url: next.url } : null;
     props["prevMenuItem"] = prev ? { name: prev.name, url: prev.url } : null;


### PR DESCRIPTION
When users click the  ` Suggest edits` button on the bottom right of any page, it takes them to a hardcoded link: the [Documentation request](https://github.com/open-metadata/OpenMetadata/issues/new?assignees=&labels=documentation&template=doc_update.md&title=) issue template in the OpenMetadata repo.

This PR makes it so that clicking the button will take users to the `.md` source file of the page in the OpenMetadata repo instead. Doing so allows users to:
- click the button and be taken to the source code of the relevant page
- edit the page content (GH edits a user-fork of the page)
- easily submit a PR for minor content edits